### PR TITLE
Retirar SecretKey dos exemplos da sdk de java

### DIFF
--- a/src/main/java/examples/address/CreateAddress.java
+++ b/src/main/java/examples/address/CreateAddress.java
@@ -9,32 +9,32 @@ import com.mundipagg.api.models.*;
 import java.util.LinkedHashMap;
 
 public class CreateAddress {
-	
-	public static void main(String[] args) {
-		
-		String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
-        
+
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
-        
+
         CustomersController customers_controller = new CustomersController();
-        
+
         String customerId = "cus_PzRyp10FeNca2rVB";
-                
+
         CreateAddressRequest request = new CreateAddressRequest();
-        
+
         request.setLine1("10880, Malibu Point, Malibu Central");
-        request.setLine2("7º floor");
+        request.setLine2("7ï¿½ floor");
         request.setZipCode("90265");
         request.setCity("Malibu");
         request.setState("CA");
         request.setCountry("US");
         LinkedHashMap<String, String> metadata = new LinkedHashMap<String, String>();
-        metadata.put("id","my_address_id");
+        metadata.put("id", "my_address_id");
         UpdateMetadataRequest updateMetadata = new UpdateMetadataRequest();
         updateMetadata.setMetadata(metadata);
         request.setMetadata(updateMetadata.getMetadata());
-        
+
         customers_controller.createAddressAsync(customerId, request, null, new APICallBack<GetAddressResponse>() {
             @Override
             public void onSuccess(HttpContext context, GetAddressResponse response) {
@@ -53,6 +53,6 @@ public class CreateAddress {
                 error.printStackTrace();
 
             }
-        });		
-	}
+        });
+    }
 }

--- a/src/main/java/examples/cards/CreateCard.java
+++ b/src/main/java/examples/cards/CreateCard.java
@@ -9,7 +9,7 @@ public class CreateCard {
 
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -27,11 +27,11 @@ public class CreateCard {
         request.setExpYear(25);
         request.setCvv("351");
 
-        //Brand is Optional field
+        // Brand is Optional field
         request.setBrand("Mastercard");
         request.setPrivateLabel(false);
 
-        //Billing Address
+        // Billing Address
         request.setBillingAddress(new CreateAddressRequest());
         request.getBillingAddress().setLine1("10880, Malibu Point, Malibu Central");
         request.getBillingAddress().setLine2("7º floor");
@@ -39,8 +39,8 @@ public class CreateCard {
         request.getBillingAddress().setCity("Malibu");
         request.getBillingAddress().setState("CA");
         request.getBillingAddress().setCountry("US");
-        
-        //Card Options: Verify OneDollarAuth
+
+        // Card Options: Verify OneDollarAuth
         request.setOptions(new CreateCardOptionsRequest());
         request.getOptions().setVerifyCard(true);
 

--- a/src/main/java/examples/cards/GetCards.java
+++ b/src/main/java/examples/cards/GetCards.java
@@ -7,10 +7,10 @@ import com.mundipagg.api.models.GetCardResponse;
 import com.mundipagg.api.models.ListCardsResponse;
 
 public class GetCards {
-    
+
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -28,7 +28,7 @@ public class GetCards {
 
                 response.getData().isEmpty();
 
-                if(response.getData().isEmpty()) {
+                if (response.getData().isEmpty()) {
                     System.out.println("My wallet is empty");
                 } else {
                     for (GetCardResponse cardItem : response.getData()) {

--- a/src/main/java/examples/charge/CaptureCharge.java
+++ b/src/main/java/examples/charge/CaptureCharge.java
@@ -6,12 +6,11 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.CreateCaptureChargeRequest;
 import com.mundipagg.api.models.GetChargeResponse;
 
-
 public class CaptureCharge {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/charge/CreateCancelCharge.java
+++ b/src/main/java/examples/charge/CreateCancelCharge.java
@@ -7,10 +7,10 @@ import com.mundipagg.api.models.GetChargeResponse;
 import com.mundipagg.api.http.client.*;
 
 public class CreateCancelCharge {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/charge/CreateCancelChargePartial.java
+++ b/src/main/java/examples/charge/CreateCancelChargePartial.java
@@ -6,12 +6,11 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.CreateCancelChargeRequest;
 import com.mundipagg.api.models.GetChargeResponse;
 
-
 public class CreateCancelChargePartial {
 
-	public static void main(String[] args) {
+    public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/charge/CreateCaptureChargePartial.java
+++ b/src/main/java/examples/charge/CreateCaptureChargePartial.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.models.CreateCaptureChargeRequest;
 import com.mundipagg.api.models.GetChargeResponse;
 
 public class CreateCaptureChargePartial {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/charge/GetChargeById.java
+++ b/src/main/java/examples/charge/GetChargeById.java
@@ -6,10 +6,10 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.GetChargeResponse;
 
 public class GetChargeById {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/charge/RetryCharge.java
+++ b/src/main/java/examples/charge/RetryCharge.java
@@ -7,10 +7,10 @@ import com.mundipagg.api.http.client.HttpContext;
 import com.mundipagg.api.models.GetChargeResponse;
 
 public class RetryCharge {
-	
-	public static void main(String[] args) {
-		
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/customer/CreateCustomer.java
+++ b/src/main/java/examples/customer/CreateCustomer.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.controllers.*;
 import java.util.LinkedHashMap;
 
 public class CreateCustomer {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_EegqODfvktNJn4YA"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -33,7 +33,7 @@ public class CreateCustomer {
         request.getAddress().setState("RJ");
         request.getAddress().setCountry("BR");
         LinkedHashMap<String, String> metadata = new LinkedHashMap<String, String>();
-        metadata.put("id","my_address_id");
+        metadata.put("id", "my_address_id");
         UpdateMetadataRequest updateMetadata = new UpdateMetadataRequest();
         updateMetadata.setMetadata(metadata);
         request.getAddress().setMetadata(updateMetadata.getMetadata());

--- a/src/main/java/examples/customer/GetCustomerById.java
+++ b/src/main/java/examples/customer/GetCustomerById.java
@@ -7,10 +7,10 @@ import com.mundipagg.api.http.client.HttpContext;
 import com.mundipagg.api.models.GetCustomerResponse;
 
 public class GetCustomerById {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/customer/UpdateCustomer.java
+++ b/src/main/java/examples/customer/UpdateCustomer.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.models.GetCustomerResponse;
 import com.mundipagg.api.models.UpdateCustomerRequest;
 
 public class UpdateCustomer {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/invoice/GetInvoiceById.java
+++ b/src/main/java/examples/invoice/GetInvoiceById.java
@@ -9,7 +9,7 @@ public class GetInvoiceById {
 
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/marketplace/CreateAnticipation.java
+++ b/src/main/java/examples/marketplace/CreateAnticipation.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.http.client.*;
 import org.joda.time.DateTime;
 
 public class CreateAnticipation {
-    
+
     public static void main(String[] args) {
-        
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -26,21 +26,22 @@ public class CreateAnticipation {
 
         String recipientId = "rp_RElaP4NMCJu08V9m";
 
-        recipients_controller.createAnticipationAsync(recipientId, request, null, new APICallBack<GetAnticipationResponse>() {
-            @Override
-            public void onSuccess(HttpContext context, GetAnticipationResponse response) {
-                System.out.println("Anticipation create!");
-                System.out.println("Anticipation ID: " + response.getId());
-            }
+        recipients_controller.createAnticipationAsync(recipientId, request, null,
+                new APICallBack<GetAnticipationResponse>() {
+                    @Override
+                    public void onSuccess(HttpContext context, GetAnticipationResponse response) {
+                        System.out.println("Anticipation create!");
+                        System.out.println("Anticipation ID: " + response.getId());
+                    }
 
-            @Override
-            public void onFailure(HttpContext context, Throwable error) {
+                    @Override
+                    public void onFailure(HttpContext context, Throwable error) {
 
-                System.out.println("Status response: " + context.getResponse().getStatusCode());
-                System.out.println(error.getMessage());
-                error.printStackTrace();
+                        System.out.println("Status response: " + context.getResponse().getStatusCode());
+                        System.out.println(error.getMessage());
+                        error.printStackTrace();
 
-            }
-        });
+                    }
+                });
     }
 }

--- a/src/main/java/examples/marketplace/CreateRecipient.java
+++ b/src/main/java/examples/marketplace/CreateRecipient.java
@@ -9,10 +9,10 @@ import com.mundipagg.api.models.CreateRecipientRequest;
 import com.mundipagg.api.models.GetRecipientResponse;
 
 public class CreateRecipient {
-    
+
     public static void main(String[] args) {
-        
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -26,7 +26,6 @@ public class CreateRecipient {
         request.setDescription("Recebedor tony stark");
         request.setDocument("26224451990");
         request.setType("individual");
-
 
         request.setDefaultBankAccount(new CreateBankAccountRequest());
         request.getDefaultBankAccount().setHolderName("Tony Stark");
@@ -58,7 +57,6 @@ public class CreateRecipient {
 
             }
         });
-
 
     }
 }

--- a/src/main/java/examples/marketplace/CreateSplit.java
+++ b/src/main/java/examples/marketplace/CreateSplit.java
@@ -11,7 +11,7 @@ public class CreateSplit {
 
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -60,7 +60,6 @@ public class CreateSplit {
         splitItemTwo.setRecipientId("rp_4jl0ra2h3bI8VBvR");
         splitItemTwo.setAmount(100000);
         splitItemTwo.setType("flat");
-
 
         List<CreateSplitRequest> listSplit = new ArrayList<CreateSplitRequest>();
         listSplit.add(splitItemOne);

--- a/src/main/java/examples/marketplace/CreateTransfer.java
+++ b/src/main/java/examples/marketplace/CreateTransfer.java
@@ -9,7 +9,7 @@ public class CreateTransfer {
 
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/order/CreateOrderBankSlip.java
+++ b/src/main/java/examples/order/CreateOrderBankSlip.java
@@ -9,10 +9,10 @@ import org.joda.time.DateTime;
 import java.util.ArrayList;
 
 public class CreateOrderBankSlip {
-	
-	public static void main(String[] args) {
-		
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -53,7 +53,6 @@ public class CreateOrderBankSlip {
         ArrayList<CreatePaymentRequest> lisPaymentItem = new ArrayList<CreatePaymentRequest>();
         lisPaymentItem.add(paymentItem);
         request.setPayments(lisPaymentItem);
-
 
         orders_controller.createOrderAsync(request, null, new APICallBack<GetOrderResponse>() {
             public void onSuccess(HttpContext context, GetOrderResponse response) {

--- a/src/main/java/examples/order/CreateOrderBankTransfer.java
+++ b/src/main/java/examples/order/CreateOrderBankTransfer.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.http.client.*;
 import java.util.ArrayList;
 
 public class CreateOrderBankTransfer {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/order/CreateOrderCheckout.java
+++ b/src/main/java/examples/order/CreateOrderCheckout.java
@@ -12,18 +12,16 @@ public class CreateOrderCheckout {
 
     public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_q73YODBFQhyV9mod"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
 
         OrdersController orders_controller = new OrdersController();
 
-
         CreateCustomerRequest create_customer_request = new CreateCustomerRequest();
         create_customer_request.setName("Tony Stark");
         create_customer_request.setEmail("tonystark@avengers.com");
-
 
         CreateCheckoutPaymentRequest create_checkout_payment_request = new CreateCheckoutPaymentRequest();
         create_checkout_payment_request.setCustomerEditable(false);
@@ -34,7 +32,6 @@ public class CreateOrderCheckout {
         acceptedPaymentMethods.add("bank_transfer");
         acceptedPaymentMethods.add("debit_card");
         create_checkout_payment_request.setAcceptedPaymentMethods(acceptedPaymentMethods);
-
 
         ArrayList<ArrayList<String>> multiPayments = new ArrayList<ArrayList<String>>();
         ArrayList<String> paymentOne = new ArrayList<String>();
@@ -56,16 +53,13 @@ public class CreateOrderCheckout {
         banksTransfer.add("341");
         create_checkout_payment_request.getBankTransfer().setBank(banksTransfer);
 
-
         create_checkout_payment_request.setBoleto(new CreateCheckoutBoletoPaymentRequest());
         create_checkout_payment_request.getBoleto().setBank("033");
         create_checkout_payment_request.getBoleto().setInstructions("Pagar ate o vencimento");
         create_checkout_payment_request.getBoleto().setDueAt(DateTime.parse("2021-07-25T00:00:00Z"));
 
-
         create_checkout_payment_request.setCreditCard(new CreateCheckoutCreditCardPaymentRequest());
         create_checkout_payment_request.getCreditCard().setStatementDescriptor("Descriptor example");
-
 
         CreateCheckoutCardInstallmentOptionRequest create_checkout_card_installment_option_request_one = new CreateCheckoutCardInstallmentOptionRequest();
         create_checkout_card_installment_option_request_one.setNumber(1);
@@ -78,13 +72,14 @@ public class CreateOrderCheckout {
         listInstallment.add(create_checkout_card_installment_option_request_two);
         create_checkout_payment_request.getCreditCard().setInstallments(listInstallment);
 
-
         create_checkout_payment_request.setDebitCard(new CreateCheckoutDebitCardPaymentRequest());
         create_checkout_payment_request.getDebitCard().setAuthentication(new CreatePaymentAuthenticationRequest());
         create_checkout_payment_request.getDebitCard().getAuthentication().setType("threed_secure");
-        create_checkout_payment_request.getDebitCard().getAuthentication().setThreedSecure(new CreateThreeDSecureRequest());
+        create_checkout_payment_request.getDebitCard().getAuthentication()
+                .setThreedSecure(new CreateThreeDSecureRequest());
         create_checkout_payment_request.getDebitCard().getAuthentication().getThreedSecure().setMpi("acquirer");
-        create_checkout_payment_request.getDebitCard().getAuthentication().getThreedSecure().setSuccessUrl("https://www.mundipagg.com");
+        create_checkout_payment_request.getDebitCard().getAuthentication().getThreedSecure()
+                .setSuccessUrl("https://www.mundipagg.com");
 
         CreateOrderRequest request = new CreateOrderRequest();
         request.setCode("test-SDK-Java");
@@ -106,7 +101,6 @@ public class CreateOrderCheckout {
         request.setPayments(listPaymentItems);
 
         request.setCustomer(create_customer_request);
-
 
         orders_controller.createOrderAsync(request, null, new APICallBack<GetOrderResponse>() {
             @Override

--- a/src/main/java/examples/order/CreateOrderCreditCard.java
+++ b/src/main/java/examples/order/CreateOrderCreditCard.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.models.*;
 import java.util.ArrayList;
 
 public class CreateOrderCreditCard {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/order/CreateOrderDebitCard.java
+++ b/src/main/java/examples/order/CreateOrderDebitCard.java
@@ -9,10 +9,10 @@ import com.mundipagg.api.models.*;
 import java.util.ArrayList;
 
 public class CreateOrderDebitCard {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -31,7 +31,6 @@ public class CreateOrderDebitCard {
         create_debit_card_payment_request.getCard().setExpMonth(1);
         create_debit_card_payment_request.getCard().setExpYear(2025);
         create_debit_card_payment_request.getCard().setCvv("123");
-
 
         CreateOrderRequest request = new CreateOrderRequest();
 

--- a/src/main/java/examples/order/CreateOrderEmpty.java
+++ b/src/main/java/examples/order/CreateOrderEmpty.java
@@ -9,10 +9,10 @@ import com.mundipagg.api.models.*;
 import java.util.ArrayList;
 
 public class CreateOrderEmpty {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/order/CreateOrderVoucher.java
+++ b/src/main/java/examples/order/CreateOrderVoucher.java
@@ -8,10 +8,10 @@ import com.mundipagg.api.models.*;
 import java.util.ArrayList;
 
 public class CreateOrderVoucher {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_q73YODBFQhyV9mod"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -49,7 +49,6 @@ public class CreateOrderVoucher {
         ArrayList<CreatePaymentRequest> lisPaymentItem = new ArrayList<CreatePaymentRequest>();
         lisPaymentItem.add(paymentItem);
         request.setPayments(lisPaymentItem);
-
 
         orders_controller.createOrderAsync(request, null, new APICallBack<GetOrderResponse>() {
             public void onSuccess(HttpContext context, GetOrderResponse response) {

--- a/src/main/java/examples/order/GetOrderById.java
+++ b/src/main/java/examples/order/GetOrderById.java
@@ -6,10 +6,10 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.GetOrderResponse;
 
 public class GetOrderById {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_q73YODBFQhyV9mod"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/plan/CreatePlan.java
+++ b/src/main/java/examples/plan/CreatePlan.java
@@ -10,7 +10,7 @@ import java.util.*;
 public class CreatePlan {
 
     public static void main(String[] args) {
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -26,41 +26,35 @@ public class CreatePlan {
         request.setBillingType("prepaid");
         request.setMinimumPrice(10000);
 
-
-        int[] numberOfInstallments = {3};
+        int[] numberOfInstallments = { 3 };
         List<Integer> listInstallments = new ArrayList<>(numberOfInstallments.length);
         for (int installments : numberOfInstallments) {
             listInstallments.add(installments);
         }
         request.setInstallments(listInstallments);
 
-
-        String[] typesOfPaymentMethods = {"credit_card", "boleto"};
+        String[] typesOfPaymentMethods = { "credit_card", "boleto" };
         List<String> listPaymentMethods = new ArrayList<>(typesOfPaymentMethods.length);
         listPaymentMethods.addAll(Arrays.asList(typesOfPaymentMethods));
         request.setPaymentMethods(listPaymentMethods);
-
 
         CreatePlanItemRequest planItemOne = new CreatePlanItemRequest();
         planItemOne.setName("Musculação");
         planItemOne.setQuantity(1);
         planItemOne.setPricingScheme(new CreatePricingSchemeRequest());
         planItemOne.getPricingScheme().setPrice(18990);
-        
+
         CreatePlanItemRequest planItemTwo = new CreatePlanItemRequest();
         planItemTwo.setName("Matrícula");
         planItemTwo.setCycles(1);
         planItemTwo.setQuantity(1);
         planItemTwo.setPricingScheme(new CreatePricingSchemeRequest());
         planItemTwo.getPricingScheme().setPrice(18990);
-        
+
         List<CreatePlanItemRequest> listPlan = new ArrayList<CreatePlanItemRequest>();
         listPlan.add(planItemOne);
         listPlan.add(planItemTwo);
         request.setItems(listPlan);
-        
-
-
 
         plans_controller.createPlanAsync(request, null, new APICallBack<GetPlanResponse>() {
             @Override

--- a/src/main/java/examples/subscription/CreateCancelSubscription.java
+++ b/src/main/java/examples/subscription/CreateCancelSubscription.java
@@ -6,10 +6,10 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.*;
 
 public class CreateCancelSubscription {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -22,24 +22,25 @@ public class CreateCancelSubscription {
 
         request.setCancelPendingInvoices(true);
 
-        subscriptions_controller.cancelSubscriptionAsync(subscriptionId, request, null, new APICallBack<GetSubscriptionResponse>() {
-            public void onSuccess(HttpContext context, GetSubscriptionResponse response) {
+        subscriptions_controller.cancelSubscriptionAsync(subscriptionId, request, null,
+                new APICallBack<GetSubscriptionResponse>() {
+                    public void onSuccess(HttpContext context, GetSubscriptionResponse response) {
 
-                System.out.println("Status response: " + context.getResponse().getStatusCode());
-                System.out.println("Subscription cancel !");
-                System.out.println("Subscription id: " + response.getId());
-                System.out.println("Subscription status: " + response.getStatus());
+                        System.out.println("Status response: " + context.getResponse().getStatusCode());
+                        System.out.println("Subscription cancel !");
+                        System.out.println("Subscription id: " + response.getId());
+                        System.out.println("Subscription status: " + response.getStatus());
 
-            }
+                    }
 
-            public void onFailure(HttpContext context, Throwable error) {
+                    public void onFailure(HttpContext context, Throwable error) {
 
-                System.out.println("Status response: " + context.getResponse().getStatusCode());
-                System.out.println(error.getMessage());
-                error.printStackTrace();
+                        System.out.println("Status response: " + context.getResponse().getStatusCode());
+                        System.out.println(error.getMessage());
+                        error.printStackTrace();
 
-            }
-        });
+                    }
+                });
     }
 
 }

--- a/src/main/java/examples/subscription/CreateSubscriptionPrePaidBankSlip.java
+++ b/src/main/java/examples/subscription/CreateSubscriptionPrePaidBankSlip.java
@@ -9,10 +9,10 @@ import com.mundipagg.api.models.*;
 import java.util.*;
 
 public class CreateSubscriptionPrePaidBankSlip {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -39,7 +39,7 @@ public class CreateSubscriptionPrePaidBankSlip {
         discountRequest.setCycles(3);
         discountRequest.setValue(10);
         discountRequest.setDiscountType("percentage");
-        ArrayList<CreateDiscountRequest> listDiscountItem =  new ArrayList<CreateDiscountRequest>();
+        ArrayList<CreateDiscountRequest> listDiscountItem = new ArrayList<CreateDiscountRequest>();
         listDiscountItem.add(discountRequest);
         request.setDiscounts(listDiscountItem);
 
@@ -50,20 +50,19 @@ public class CreateSubscriptionPrePaidBankSlip {
         listIncrementItem.add(incrementRequest);
         request.setIncrements(listIncrementItem);
 
-
         CreateSubscriptionItemRequest create_subscription_item_request_one = new CreateSubscriptionItemRequest();
         create_subscription_item_request_one.setDescription("Musculação");
         create_subscription_item_request_one.setQuantity(1);
         create_subscription_item_request_one.setPricingScheme(new CreatePricingSchemeRequest());
         create_subscription_item_request_one.getPricingScheme().setPrice(18990);
-        
+
         CreateSubscriptionItemRequest create_subscription_item_request_two = new CreateSubscriptionItemRequest();
         create_subscription_item_request_two.setDescription("Matrícula");
         create_subscription_item_request_two.setQuantity(1);
         create_subscription_item_request_two.setCycles(1);
         create_subscription_item_request_two.setPricingScheme(new CreatePricingSchemeRequest());
         create_subscription_item_request_two.getPricingScheme().setPrice(5990);
-        
+
         List<CreateSubscriptionItemRequest> listItem = new ArrayList<CreateSubscriptionItemRequest>();
         listItem.add(create_subscription_item_request_one);
         listItem.add(create_subscription_item_request_two);

--- a/src/main/java/examples/subscription/CreateSubscriptionPrePaidCreditCard.java
+++ b/src/main/java/examples/subscription/CreateSubscriptionPrePaidCreditCard.java
@@ -9,10 +9,10 @@ import com.mundipagg.api.models.*;
 import java.util.*;
 
 public class CreateSubscriptionPrePaidCreditCard {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -35,7 +35,6 @@ public class CreateSubscriptionPrePaidCreditCard {
         request.getCustomer().setName("Tony Stark'");
         request.getCustomer().setEmail("tonystark@avengers.com");
 
-
         request.setCard(new CreateCardRequest());
         request.getCard().setHolderName("ony Stark");
         request.getCard().setNumber("4000000000000010");
@@ -55,7 +54,7 @@ public class CreateSubscriptionPrePaidCreditCard {
         discountRequest.setCycles(3);
         discountRequest.setValue(10);
         discountRequest.setDiscountType("percentage");
-        ArrayList<CreateDiscountRequest> listDiscountItem =  new ArrayList<CreateDiscountRequest>();
+        ArrayList<CreateDiscountRequest> listDiscountItem = new ArrayList<CreateDiscountRequest>();
         listDiscountItem.add(discountRequest);
         request.setDiscounts(listDiscountItem);
 
@@ -71,21 +70,19 @@ public class CreateSubscriptionPrePaidCreditCard {
         create_subscription_item_request_one.setQuantity(1);
         create_subscription_item_request_one.setPricingScheme(new CreatePricingSchemeRequest());
         create_subscription_item_request_one.getPricingScheme().setPrice(18990);
-        
+
         CreateSubscriptionItemRequest create_subscription_item_request_two = new CreateSubscriptionItemRequest();
         create_subscription_item_request_two.setDescription("Matrícula");
         create_subscription_item_request_two.setQuantity(1);
         create_subscription_item_request_two.setCycles(1);
         create_subscription_item_request_two.setPricingScheme(new CreatePricingSchemeRequest());
         create_subscription_item_request_two.getPricingScheme().setPrice(5990);
-        
-        
+
         List<CreateSubscriptionItemRequest> listItem = new ArrayList<CreateSubscriptionItemRequest>();
         listItem.add(create_subscription_item_request_one);
         listItem.add(create_subscription_item_request_two);
 
         request.setItems(listItem);
-
 
         subscriptions_controller.createSubscriptionAsync(request, null, new APICallBack<GetSubscriptionResponse>() {
             public void onSuccess(HttpContext context, GetSubscriptionResponse response) {

--- a/src/main/java/examples/subscription/GetSubscriptionById.java
+++ b/src/main/java/examples/subscription/GetSubscriptionById.java
@@ -6,10 +6,10 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.GetSubscriptionResponse;
 
 public class GetSubscriptionById {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);

--- a/src/main/java/examples/subscription/UpdateSubscription.java
+++ b/src/main/java/examples/subscription/UpdateSubscription.java
@@ -6,10 +6,10 @@ import com.mundipagg.api.http.client.*;
 import com.mundipagg.api.models.*;
 
 public class UpdateSubscription {
-	
-	public static void main(String[] args) {
 
-        String basicAuthUserName = "sk_test_4tdVXpseumRmqbo"; // The username to use with basic authentication
+    public static void main(String[] args) {
+
+        String basicAuthUserName = "sk_test"; // The username to use with basic authentication
         String basicAuthPassword = ""; // The password to use with basic authentication
 
         MundiAPIClient client = new MundiAPIClient(basicAuthUserName, basicAuthPassword);
@@ -35,23 +35,24 @@ public class UpdateSubscription {
         request.getCard().getBillingAddress().setState("RJ");
         request.getCard().getBillingAddress().setCountry("BR");
 
-        subscriptions_controller.updateSubscriptionCardAsync(subscriptionId, request, null, new APICallBack<GetSubscriptionResponse>() {
-            public void onSuccess(HttpContext context, GetSubscriptionResponse response) {
-                System.out.println("Card updated !");
-                System.out.println("Status response: " + context.getResponse().getStatusCode());
-                System.out.println("Card id: " + response.getCard().getId());
-                System.out.println("First six digits: " + response.getCard().getFirstSixDigits());
-                System.out.println("Last four digits: " + response.getCard().getLastFourDigits());
-            }
+        subscriptions_controller.updateSubscriptionCardAsync(subscriptionId, request, null,
+                new APICallBack<GetSubscriptionResponse>() {
+                    public void onSuccess(HttpContext context, GetSubscriptionResponse response) {
+                        System.out.println("Card updated !");
+                        System.out.println("Status response: " + context.getResponse().getStatusCode());
+                        System.out.println("Card id: " + response.getCard().getId());
+                        System.out.println("First six digits: " + response.getCard().getFirstSixDigits());
+                        System.out.println("Last four digits: " + response.getCard().getLastFourDigits());
+                    }
 
-            public void onFailure(HttpContext context, Throwable error) {
+                    public void onFailure(HttpContext context, Throwable error) {
 
-                System.out.println("Status response: " + context.getResponse().getStatusCode());
-                System.out.println(error.getMessage());
-                error.printStackTrace();
+                        System.out.println("Status response: " + context.getResponse().getStatusCode());
+                        System.out.println(error.getMessage());
+                        error.printStackTrace();
 
-            }
-        });
+                    }
+                });
     }
 
 }


### PR DESCRIPTION
## O que
Olhando  com calma nosso exemplo da SDK de  java, verificamos que temos sk_test espalhadas por eles. Portanto, como estamos em busca de pontos de falha de segurança que engloba nossa ecossistema, devemos retira essas informações delicadas de lá.